### PR TITLE
Add syntax highlighting to singular kernel

### DIFF
--- a/jupyter_kernel_singular/singular-mode/main.js
+++ b/jupyter_kernel_singular/singular-mode/main.js
@@ -1,0 +1,15 @@
+// Notebook Extension to allow singular Mode on Jupyter
+
+define([
+  'base/js/namespace',
+  './singular'
+], function (Jupyter) {
+  "use strict";
+
+  return {
+    load_ipython_extension: function () {
+      console.log('Loading singular Mode...');
+    }
+  };
+
+});

--- a/jupyter_kernel_singular/singular-mode/singular.js
+++ b/jupyter_kernel_singular/singular-mode/singular.js
@@ -1,0 +1,58 @@
+define([
+    'codemirror/lib/codemirror',
+    'codemirror/addon/mode/simple'
+], function (CodeMirror) {
+    'use strict';
+
+    var keyword = RegExp(['(?:apply|break|breakpoint|continue|else|export|exportto|for|if|importfrom|',
+        'keepring|load|quit|return|while)\\b'].join(''))
+    var type = RegExp(['(?:bigint|bigintmat|def|ideal|int|intmat|intvec|link|list|map|matrix|module|',
+        'number|package|poly|proc|resolution|ring|string|vector|User|cone|fan|polytope|',
+        'pyobject|reference|shared)\\b'].join(''))
+    var builtin = RegExp(['(?:align|attrib|bareiss|betti|char|char_series|charstr|chinrem|cleardenom|close|coef|coeffs|',
+        'contract|datetime|dbprint|defined|deg|degree|delete|denominator|det|diff|dim|division|dump|eliminate|eval|',
+        'ERROR|example|execute|extgcd|facstd|factmodd|factorize|farey|fetch|fglm|fglmquot|files|find|finduni|',
+        'fprintf|freemodule|frwalk|gcd|gen|getdump|groebner|help|highcorner|hilb|homog|hres|imap|impart|indepSet|',
+        'insert|interpolation|interred|intersect|jacob|janet|jet|kbase|kernel|kill|killattrib|koszul|laguerre|lead|',
+        'leadcoef|leadexp|leadmonom|LIB|lift|liftstd|listvar|lres|ludecomp|luinverse|lusolve|max|maxideal|memory|',
+        'min|minbase|minor|minres|modulo|monitor|monomial|mpresmat|mres|mstd|mult|nameof|names|ncols|npars|nres|',
+        'nrows|numerator|nvars|open|option|ord|ordstr|par|pardeg|parstr|preimage|prime|primefactors|print|printf|',
+        'prune|qhweight|qrds|quit|quote|quotient|random|rank|read|reduce|regularity|repart|res|reservedName|',
+        'resultant|ringlist|ring_list|rvar|sba|setring|simplex|simplify|size|slimgb|sortvec|sqrfree|sprintf|sres|',
+        'status|std|stdfglm|stdhilb|subst|system|syz|trace|transpose|type|typeof|univariate|uressolve|vandermonde|',
+        'var|variables|varstr|vdim|waitall|waitfirst|wedge|weight|weightKB|write)\\b'].join(''))
+
+    CodeMirror.defineSimpleMode("singular", {
+        // The start state contains the rules that are intially used
+        start: [
+            {regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: "string"},
+            {regex: keyword, token: "keyword"},
+            {regex: type, token: "qualifier"},
+            {regex: builtin, token: "builtin"},
+            {regex: /0x[a-f\d]+|[-+]?(?:\.\d+|\d+\.?\d*)(?:e[-+]?\d+)?/i, token: "number"},
+            {regex: /\/\/.*/, token: "comment"},
+            {regex: /\/(?:[^\\]|\\.)*?\//, token: "variable-3"},
+            // A next property will cause the mode to move to a different state
+            {regex: /\/\*/, token: "comment", next: "comment"},
+            {regex: /[-+\/*=<>!]+/, token: "operator"},
+            // indent and dedent properties guide autoindentation
+            {regex: /[\{\[\(]/, indent: true},
+            {regex: /[\}\]\)]/, dedent: true},
+            {regex: /[a-z$][\w$]*/, token: "variable"}
+        ],
+        // The multi-line comment state.
+        comment: [
+            {regex: /.*?\*\//, token: "comment", next: "start"},
+            {regex: /.*/, token: "comment"}
+        ],
+        // The meta property contains global information about the mode. It
+        // can contain properties like lineComment, which are supported by
+        // all modes, and also directives like dontIndentStates, which are
+        // specific to simple modes.
+        meta: {
+            dontIndentStates: ["comment"],
+            lineComment: "//"
+        }
+    });
+    CodeMirror.defineMIME('text/x-singular', 'singular');
+});

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-import sys
+from glob import glob
 from distutils.core import setup
+from setuptools.command.install import install as _install
 
 import json
 import os
@@ -14,31 +15,36 @@ from os.path import dirname,abspath
 
 from shutil import copy as file_copy
 
+kernelpath = os.path.join("share", "jupyter", "kernels", "singular")
+nbextpath = os.path.join("share", "jupyter", "nbextensions", "singular-mode")
 
 kernel_json = {"argv":[sys.executable,"-m","jupyter_kernel_singular", "-f", "{connection_file}"],
  "display_name":"Singular",
  "language":"singular",
- "codemirror_mode":"singular", # note that this does not exist yet
+ "codemirror_mode":"singular",
  "env":{"PS1": "$"}
 }
 
-def install_my_kernel_spec(user=True):
-    with TemporaryDirectory() as td:
-        os.chmod(td, 0o755) # Starts off as 700, not user readable
-        with open(os.path.join(td, 'kernel.json'), 'w') as f:
-            json.dump(kernel_json, f, sort_keys=True)
-        path_of_file = dirname( abspath(__file__) ) + "/jupyter_kernel_singular/resources/"
-        file_copy(path_of_file + "logo-32x32.png", td )
-        file_copy(path_of_file + "logo-64x64.png", td )
-        print('Installing IPython kernel spec')
-        install_kernel_spec(td, 'Singular', user=user, replace=True)
+class install(_install):
+    def run(self):
+        from notebook.nbextensions import enable_nbextension, install_nbextension
+        # run from distutils install
+        _install.run(self)
 
-def main(argv=None):
-    install_my_kernel_spec()
+        #install kernel specs
+        with TemporaryDirectory() as td:
+            os.chmod(td, 0o755) # Starts off as 700, not user readable
+            with open(os.path.join(td, 'kernel.json'), 'w') as f:
+                json.dump(kernel_json, f, sort_keys=True)
+            path_of_file = dirname( abspath(__file__) ) + "/jupyter_kernel_singular/resources/"
+            file_copy(path_of_file + "logo-32x32.png", td )
+            file_copy(path_of_file + "logo-64x64.png", td )
+            print('Installing IPython kernel spec')
+            install_kernel_spec(td, 'Singular', user=self.user, replace=True)
 
-if __name__ == '__main__':
-    main()
-
+        #install codemirror notebook extension
+        install_nbextension('jupyter_kernel_singular/singular-mode', overwrite=True, user=self.user)
+        enable_nbextension('notebook', 'singular-mode/main')
 
 setup( name="jupyter_kernel_singular"
      , version="0.9.4"
@@ -48,5 +54,6 @@ setup( name="jupyter_kernel_singular"
      , url="https://github.com/sebasguts/jupyter-singular"
      , packages=["jupyter_kernel_singular"]
      , package_dir={"jupyter_kernel_singular": "jupyter_kernel_singular"}
-     , package_data={"jupyter_kernel_singular": ["resources/logo-32x32.png","resources/logo-64x64.png"]}
+     , data_files=[(kernelpath, glob("resources/*")), (nbextpath, glob("singular-mode/*"))]
+     , cmdclass={'install':install}
      )


### PR DESCRIPTION
Add a codemirror "SimpleMode" to singular kernel
Modify setup.py (previous version doesn't remove installed files under
local/share/jupyter/kernels)

Linked to [OpenDreamkit issue #175](https://github.com/OpenDreamKit/OpenDreamKit/issues/175)

@sebasguts 
I used mainly this resource https://www.singular.uni-kl.de/Manual/latest/index.htm as base to do this syntax highlight.
Please tell me if it looks up to date for you and if i am missing something important with the 
singular syntax.
About type tokens i set them to the "qualifier" kind of token, because "type" kind of token doesn't have a
css style applied with jupyter.