### PR TITLE
Remove call of install_nbextension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ kernel_json = {"argv":[sys.executable,"-m","jupyter_kernel_singular", "-f", "{co
 
 class install(_install):
     def run(self):
-        from notebook.nbextensions import enable_nbextension, install_nbextension
+        from notebook.nbextensions import enable_nbextension
         # run from distutils install
         _install.run(self)
 
@@ -36,14 +36,10 @@ class install(_install):
             os.chmod(td, 0o755) # Starts off as 700, not user readable
             with open(os.path.join(td, 'kernel.json'), 'w') as f:
                 json.dump(kernel_json, f, sort_keys=True)
-            path_of_file = dirname( abspath(__file__) ) + "/jupyter_kernel_singular/resources/"
-            file_copy(path_of_file + "logo-32x32.png", td )
-            file_copy(path_of_file + "logo-64x64.png", td )
             print('Installing IPython kernel spec')
             install_kernel_spec(td, 'Singular', user=self.user, replace=True)
 
-        #install codemirror notebook extension
-        install_nbextension('jupyter_kernel_singular/singular-mode', overwrite=True, user=self.user)
+        # enable codemirror notebook extension
         enable_nbextension('notebook', 'singular-mode/main')
 
 setup( name="jupyter_kernel_singular"
@@ -54,6 +50,7 @@ setup( name="jupyter_kernel_singular"
      , url="https://github.com/sebasguts/jupyter-singular"
      , packages=["jupyter_kernel_singular"]
      , package_dir={"jupyter_kernel_singular": "jupyter_kernel_singular"}
-     , data_files=[(kernelpath, glob("resources/*")), (nbextpath, glob("singular-mode/*"))]
-     , cmdclass={'install':install}
+     , data_files=[(kernelpath, glob("jupyter_kernel_singular/resources/*")),
+                   (nbextpath, glob("jupyter_kernel_singular/singular-mode/*"))]
+     , cmdclass={'install': install}
      )


### PR DESCRIPTION
As jdemeyer stated in pari_jupyter [PR5](https://github.com/jdemeyer/pari_jupyter/pull/5) 
install_nbextension seems to be buggy (on some config it try to install file under` /usr/local/share/jupyter` even with pip install --user option)
see (https://github.com/jupyter/notebook/issues/1706).

- Remove the call of install_nbextension
- Use data_files instead with fixed path (old paths where wrongs)