### PR TITLE
Remove unused imports

### DIFF
--- a/jupyter_kernel_singular/kernel.py
+++ b/jupyter_kernel_singular/kernel.py
@@ -1,18 +1,12 @@
 from ipykernel.kernelbase import Kernel
 
-from subprocess import check_output
-from os import unlink, path
-
 import base64
-import imghdr
 import re
 import signal
-import urllib
 import pexpect
 from pexpect import replwrap, EOF, which
 
-from ipykernel.comm import Comm
-from ipykernel.comm import CommManager
+#from ipykernel.comm import CommManager
 
 import sys
 


### PR DESCRIPTION
Fixes https://github.com/sebasguts/jupyter_kernel_singular/issues/12.  Remove imports, including imghdr, that are not used in the code.  I commented out the CommManager import, rather than removing it, because there is commented code that uses CommManager.
