### PR TITLE
Fix imports for Python 3.13, add pyproject.toml to declare build dependencies

### DIFF
--- a/jupyter_kernel_singular/kernel.py
+++ b/jupyter_kernel_singular/kernel.py
@@ -1,18 +1,12 @@
 from ipykernel.kernelbase import Kernel
 
-from subprocess import check_output
-from os import unlink, path
-
 import base64
-import imghdr
 import re
 import signal
-import urllib
 import pexpect
 from pexpect import replwrap, EOF, which
 
-from ipykernel.comm import Comm
-from ipykernel.comm import CommManager
+#from ipykernel.comm import CommManager
 
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    'setuptools',
+    'jupyter_client',
+    'ipython',
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
As mentioned in https://github.com/passagemath/passagemath/pull/1428#issuecomment-3177602803